### PR TITLE
Add function to calculate task revision dates

### DIFF
--- a/dates.js
+++ b/dates.js
@@ -1,0 +1,23 @@
+// Function to calculate dates revision
+export function calculateRevisionDates(startDate) {
+   const start = new Date(startDate);
+   // console.log("calculateRevisionDates called with startDate:", startDate);
+   return {
+      startDate: startDate,
+      oneWeek: new Date(
+         start.getTime() + 7 * 24 * 60 * 60 * 1000
+      ).toISOString(),
+      oneMonth: new Date(
+         start.getTime() + 30 * 24 * 60 * 60 * 1000
+      ).toISOString(),
+      threeMonths: new Date(
+         start.getTime() + 3 * 30 * 24 * 60 * 60 * 1000
+      ).toISOString(),
+      sixMonths: new Date(
+         start.getTime() + 6 * 30 * 24 * 60 * 60 * 1000
+      ).toISOString(),
+      oneYear: new Date(
+         start.setFullYear(start.getFullYear() + 1)
+      ).toISOString(),
+   };
+}

--- a/display.js
+++ b/display.js
@@ -1,0 +1,36 @@
+import { getData } from "./storage.js";
+
+// Function to display the agenda for the user selected
+export function displayAgenda(userId) {
+   const scheduleBody = document.getElementById("schedule-body");
+
+   scheduleBody.innerHTML = ""; // Clear previous content
+
+   const agenda = getData(userId); // Fetch agenda for selected user
+
+   if (!agenda || agenda.length === 0) {
+      // No agenda, show a message
+      scheduleBody.innerHTML = `
+      <tr>
+        <td colspan="7" style="text-align: center;">No agenda found for this user.</td>
+      </tr>
+    `;
+
+      return;
+   }
+
+   // If agenda exists, display it in the table
+   agenda.forEach((topic) => {
+      const row = document.createElement("tr");
+      row.innerHTML = `
+      <td>${topic.name}</td>
+      <td>${new Date(topic.startDate).toLocaleDateString()}</td>
+      <td>${new Date(topic.oneWeek).toLocaleDateString()}</td>
+      <td>${new Date(topic.oneMonth).toLocaleDateString()}</td>
+      <td>${new Date(topic.threeMonths).toLocaleDateString()}</td>
+      <td>${new Date(topic.sixMonths).toLocaleDateString()}</td>
+      <td>${new Date(topic.oneYear).toLocaleDateString()}</td>
+    `;
+      scheduleBody.appendChild(row);
+   });
+}


### PR DESCRIPTION
This update introduces a function to calculate key revision dates based on a given start date. It includes:

Computing revision milestones (1 week, 1 month, 3 months, 6 months, and 1 year).
Using JavaScript date operations to generate future dates.
Returning an object with all calculated dates in ISO format.