### PR TITLE
Set default date picker value to today's date in YYYY-MM-DD format

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,19 +4,6 @@
 // Note that when running locally, in order to open a web page which uses modules, you must serve the directory over HTTP e.g. with https://www.npmjs.com/package/http-server
 // You can't open the index.html file using a file:// URL.
 
-// This is a placeholder file which shows how you can access functions defined in other files.
-// It can be loaded into index.html.
-// You can delete the contents of the file once you have understood how it works.
-// Note that when running locally, in order to open a web page which uses modules, you must serve the directory over HTTP e.g. with https://www.npmjs.com/package/http-server
-// You can't open the index.html file using a file:// URL.
-
-// import { getUserIds } from "./storage.js";
-
-// window.onload = function () {
-//   const users = getUserIds();
-//   document.querySelector("body").innerText = `There are ${users.length} users`;
-// };
-
 import { getUserIds, addData } from "./storage.js";
 import { calculateRevisionDates } from "./dates.js";
 import { displayAgenda } from "./display.js";
@@ -26,6 +13,17 @@ const scheduleBody = document.getElementById("schedule-body");
 const form = document.getElementById("topicForm");
 const taskNameInput = document.getElementById("taskName");
 const taskDateInput = document.getElementById("taskDate");
+
+// Function to set default date in the date input field
+document.addEventListener("DOMContentLoaded", () => {
+   const today = new Date();
+   const yyyy = today.getFullYear();
+   const mm = String(today.getMonth() + 1).padStart(2, '0'); // Months are 0-based
+   const dd = String(today.getDate()).padStart(2, '0');
+
+   // Set the default date in the input field
+   taskDateInput.value = `${yyyy}-${mm}-${dd}`;
+});
 
 // Populate the dropdown with user options
 const userIds = getUserIds();


### PR DESCRIPTION
### Fix Default Date Picker to Show Today’s Date on Page Load
This PR resolves the issue where the date picker (`<input type="date">`) was displaying "dd/mm/yyyy" as a placeholder instead of defaulting to today's date.

### Changes Made:
- Added a script to set the default value of the date input field (`taskDateInput`) to today's date in `YYYY-MM-DD` format.
- Ensured that the date picker automatically fills in the correct date on page load.
- No changes were made to other files, as this fix is handled entirely in `script.js`.

### Why This Fix?
- The requirement states that the **date picker must default to today’s date on first page load**.
- The previous behavior left the field empty, showing `"dd/mm/yyyy"`, which caused confusion.
- This fix ensures that when the user opens the page, the date field is already filled with today’s date (e.g., **`2025-02-07`**).

### How to Test?
1. **Pull this branch** and run the project.
2. Refresh the page.
3. Verify that the date picker now defaults to today’s date without showing a placeholder.

 **This fix improves usability and aligns with the project requirements.**  
